### PR TITLE
feat: db request cache

### DIFF
--- a/app/api/cache.ts
+++ b/app/api/cache.ts
@@ -1,0 +1,16 @@
+let cache: { [key: string]: any } = {}
+let cacheTimestamp: number | null = null
+const CACHE_DURATION = 60 * 60 * 1000 // 1 hour cache
+
+export const setCache = (key: string, data: any) => {
+  cache[key] = data
+  cacheTimestamp = Date.now()
+}
+
+export const getCache = (key: string) => {
+  if (Date.now() - (cacheTimestamp || 0) > CACHE_DURATION) {
+    // When the cache is expired
+    return null
+  }
+  return cache[key]
+}

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -7,48 +7,51 @@ const client = new MongoClient(process.env.MONGODB_URI!)
 export type GlobalCacheKey = 'carsGlobal' | 'dealsGlobal'
 
 export async function getDealsTimeSeries(): Promise<DealRow[]> {
-  const cachedData = getCache('dealsTimeSeries')
-  if (cachedData) {
-    return cachedData
-  }
-
-  const documents = await client.db('singularity').collection('dealsTimeSeries').find({}).sort({date: 1}).toArray()
-  console.log("Got time series for deals", documents.length)
-  const data = documents.map((doc) => {
-    if (doc.qap instanceof Long) {
-      doc.qap = doc.qap.toNumber()
+    const cachedData = getCache('dealsTimeSeries')
+    if (cachedData) {
+      console.log("Cache hit for dealsTimeSeries") // Log cache hit
+      return cachedData
     }
-    return doc
-  }) as any
 
-  setCache('dealsTimeSeries', data)
-  return data
+    console.log("Fetching dealsTimeSeries from database") // Log database fetch
+    const documents = await client.db('singularity').collection('dealsTimeSeries').find({}).sort({date: 1}).toArray()
+    const data = documents.map((doc) => {
+      if (doc.qap instanceof Long) {
+        doc.qap = doc.qap.toNumber()
+      }
+      return doc
+    }) as any
+  
+    setCache('dealsTimeSeries', data)
+    return data
 }
 
 export async function getCarsTimeSeries(): Promise<CarRow[]> {
-  const cachedData = getCache('carsTimeSeries')
-  if (cachedData) {
-    return cachedData
-  }
+    const cachedData = getCache('carsTimeSeries')
+    if (cachedData) {
+        console.log("Cache hit for carsTimeSeries") // Log cache hit
+        return cachedData
+    }
 
-  const documents = await client.db('singularity').collection('carsTimeSeries').find({}).sort({date: 1}).toArray()
-  console.log("Got time series for cars", documents.length)
-  const data = documents as any
+    console.log("Fetching carsTimeSeries from database") // Log database fetch
+    const documents = await client.db('singularity').collection('carsTimeSeries').find({}).sort({date: 1}).toArray()
+    const data = documents as any
 
-  setCache('carsTimeSeries', data)
-  return data
+    setCache('carsTimeSeries', data)
+    return data
 }
 
 export async function getVerifiedClients(): Promise<VerifiedClient[]> {
-  const cachedData = getCache('verifiedClients')
-  if (cachedData) {
-    return cachedData
-  }
-
-  const documents = await client.db('singularity').collection('verifiedClients').find({}).toArray()
-  console.log("Got verified clients", documents.length)
-  const data = documents as any
-
-  setCache('verifiedClients', data)
-  return data
+    const cachedData = getCache('verifiedClients')
+    if (cachedData) {
+        console.log("Cache hit for verifiedClients") // Log cache hit
+        return cachedData
+    }
+  
+    console.log("Fetching verifiedClients from database") // Log database fetch
+    const documents = await client.db('singularity').collection('verifiedClients').find({}).toArray()
+    const data = documents as any
+  
+    setCache('verifiedClients', data)
+    return data
 }

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -1,29 +1,54 @@
-import {Long, MongoClient} from "mongodb";
-import {CarRow, DealRow, VerifiedClient} from "@/app/api/types.js";
+import { Long, MongoClient } from "mongodb"
+import { CarRow, DealRow, VerifiedClient } from "@/app/api/types.js"
+import { getCache, setCache } from './cache'
 
 const client = new MongoClient(process.env.MONGODB_URI!)
 
 export type GlobalCacheKey = 'carsGlobal' | 'dealsGlobal'
 
 export async function getDealsTimeSeries(): Promise<DealRow[]> {
-    const documents = await client.db('singularity').collection('dealsTimeSeries').find({}).sort({date: 1}).toArray()
-    console.log("Got time series for deals", documents.length)
-    return documents.map((doc) => {
-        if (doc.qap instanceof Long) {
-            doc.qap = doc.qap.toNumber()
-        }
-        return doc
-    } ) as any
+  const cachedData = getCache('dealsTimeSeries')
+  if (cachedData) {
+    return cachedData
+  }
+
+  const documents = await client.db('singularity').collection('dealsTimeSeries').find({}).sort({date: 1}).toArray()
+  console.log("Got time series for deals", documents.length)
+  const data = documents.map((doc) => {
+    if (doc.qap instanceof Long) {
+      doc.qap = doc.qap.toNumber()
+    }
+    return doc
+  }) as any
+
+  setCache('dealsTimeSeries', data)
+  return data
 }
 
 export async function getCarsTimeSeries(): Promise<CarRow[]> {
-    const documents = await client.db('singularity').collection('carsTimeSeries').find({}).sort({date: 1}).toArray()
-    console.log("Got time series for cars", documents.length)
-    return documents as any
+  const cachedData = getCache('carsTimeSeries')
+  if (cachedData) {
+    return cachedData
+  }
+
+  const documents = await client.db('singularity').collection('carsTimeSeries').find({}).sort({date: 1}).toArray()
+  console.log("Got time series for cars", documents.length)
+  const data = documents as any
+
+  setCache('carsTimeSeries', data)
+  return data
 }
 
 export async function getVerifiedClients(): Promise<VerifiedClient[]> {
-    const documents = await client.db('singularity').collection('verifiedClients').find({}).toArray()
-    console.log("Got verified clients", documents.length)
-    return documents as any
+  const cachedData = getCache('verifiedClients')
+  if (cachedData) {
+    return cachedData
+  }
+
+  const documents = await client.db('singularity').collection('verifiedClients').find({}).toArray()
+  console.log("Got verified clients", documents.length)
+  const data = documents as any
+
+  setCache('verifiedClients', data)
+  return data
 }


### PR DESCRIPTION
Adds a cache for MongoDB requests. If a request was made within the last hour, the in-memory cache is served instead. This runs server side.

Also added some real-time logs to track when the cache is hit vs. when new data is fetched from the database.

Seems to work well, but I admit it could be enhanced and a little DRYer